### PR TITLE
feat(charts): add external secrets support to cronjob template

### DIFF
--- a/charts/web-app/Chart.yaml
+++ b/charts/web-app/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: web-app
 description: A Helm chart for deploying web applications or web application micro services
 type: application
-version: 0.2.56
+version: 0.2.57
 
 dependencies:
   - name: app-iam
     version: 0.0.40
-    repository: 'https://pixovr.github.io/helm-charts'
+    repository: "https://pixovr.github.io/helm-charts"
     alias: app_iam

--- a/charts/web-app/templates/cronjob.yaml
+++ b/charts/web-app/templates/cronjob.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.enabled }}
 {{- if .Values.cronjob.enabled }}
+
+{{- $extra_secrets := .Values.external_secrets.extra_secrets }}
+{{- $has_extra_secrets := (and (kindIs "slice" $extra_secrets) (gt (len $extra_secrets) 0)) }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -41,6 +44,13 @@ spec:
           volumes:
           - name: tmp-dir
             emptyDir: {}
+          {{- if .Values.external_secrets.enabled }}
+          {{- if $has_extra_secrets }}
+          - name: extra-app-secrets
+            secret:
+              secretName: extra-app-secrets
+          {{- end }}
+          {{- end }}
 
           containers:
           - name: job
@@ -58,6 +68,12 @@ spec:
             volumeMounts:
             - mountPath: /tmp
               name: tmp-dir
+            {{- if .Values.external_secrets.enabled }}
+            {{- if $has_extra_secrets }}
+            - mountPath: /mnt/extra-secrets
+              name: extra-app-secrets
+            {{- end }}
+            {{- end }}
 
             securityContext:
               allowPrivilegeEscalation: false
@@ -75,6 +91,21 @@ spec:
             - --ignore-stdin
             {{- end }}
 
+            {{- if or .Values.cronjob.external_secrets.enabled $has_extra_secrets  }}
+            envFrom:
+
+            {{- if .Values.cronjob.external_secrets.enabled }}
+            - secretRef:
+                name: cronjob-secrets
+            {{- end }}
+
+            {{- if $has_extra_secrets }}
+            - secretRef:
+                name: extra-app-secrets
+            {{- end }}
+
+            {{- end }}
+
             env:
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
@@ -87,6 +118,13 @@ spec:
               value: '{{ include "kms_keyring_name" $ }}'
             - name: GCP_KMS_KEY_NAME
               value: '{{ include "kms_key_name" $ }}'
+            {{- end }}
+
+            {{- if .Values.external_secrets.enabled }}
+            {{- if $has_extra_secrets }}
+            - name: EXTRA_SECRETS_PATH
+              value: "/mnt/extra-secrets"
+            {{- end }}
             {{- end }}
 
             {{- range .Values.dynamicHosts }}

--- a/charts/web-app/test-output.yaml
+++ b/charts/web-app/test-output.yaml
@@ -545,6 +545,9 @@ spec:
           volumes:
           - name: tmp-dir
             emptyDir: {}
+          - name: extra-app-secrets
+            secret:
+              secretName: extra-app-secrets
 
           containers:
           - name: job
@@ -562,6 +565,8 @@ spec:
             volumeMounts:
             - mountPath: /tmp
               name: tmp-dir
+            - mountPath: /mnt/extra-secrets
+              name: extra-app-secrets
 
             securityContext:
               allowPrivilegeEscalation: false
@@ -575,6 +580,11 @@ spec:
             - dev-sample-web.test.svc:443/
             - x-access-token:$(SECRET_KEY)
             - --ignore-stdin
+            envFrom:
+            - secretRef:
+                name: cronjob-secrets
+            - secretRef:
+                name: extra-app-secrets
 
             env:
             - name: EMAILER_TO
@@ -585,6 +595,8 @@ spec:
               value: 'dev-sample-web-keyring'
             - name: GCP_KMS_KEY_NAME
               value: 'dev-sample-web-key'
+            - name: EXTRA_SECRETS_PATH
+              value: "/mnt/extra-secrets"
 
             - name: EXTERNAL_APP_URL
 

--- a/charts/web-app/test-values.yaml
+++ b/charts/web-app/test-values.yaml
@@ -79,7 +79,7 @@ sql:
 
 cronjobs:
   - name: sample
-    schedule: '0 14 * * *'
+    schedule: "0 14 * * *"
     secretMounts:
       - name: service-auth
         prefix: true
@@ -93,7 +93,7 @@ cronjobs:
       limit: .25
     image:
       self: true
-      command: ['/bin/sh']
+      command: ["/bin/sh"]
 
 cronjob:
   enabled: true
@@ -110,8 +110,8 @@ env:
 email:
   enabled: true
   mfa: true
-  sender: 'pixoplatform@pixovr.com'
-  bcc: 'newuser@pixovr.com'
+  sender: "pixoplatform@pixovr.com"
+  bcc: "newuser@pixovr.com"
 
 aws:
   bucket: test-bucket
@@ -239,4 +239,3 @@ hpa:
 pixo_service_account:
   enabled: true
   org_id: 20
-


### PR DESCRIPTION
Add support for mounting and accessing external secrets in the CronJob template:
- Mount app-secrets and extra-app-secrets volumes when enabled
- Add volume mounts to make secrets accessible to containers
- Configure envFrom to load secrets as environment variables
- Add EXTRA_SECRETS_PATH environment variable for extra secrets
- Implement conditional logic to check for extra secrets